### PR TITLE
chore(ci): add update and publish workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: docker
+    directory: "/src"
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'update/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://npm.pkg.github.com
+
+      - run: npm ci
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.pull_request.head.ref }}"
+          TAG="${TAG#update/}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          npm version "$TAG" --tag-version-prefix=""
+          npm run build
+          npm publish
+
+          git push origin main --follow-tags

--- a/.github/workflows/update.sh
+++ b/.github/workflows/update.sh
@@ -22,7 +22,7 @@ if [ -z "$tag" ]; then
 
     git -C $checkout checkout $tag >/dev/null 2>&1
 else
-    git clone --depth 1 --branch $tag $src_repo
+    git clone --depth 1 --branch $tag $src_repo $checkout
 fi
 
 # Check if the tag already exists in the current repo.

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,97 @@
+name: Update
+
+on:
+  repository_dispatch:
+    types: [new-tag]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Upstream tag to update to (leave empty for latest)'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "tag=${{ github.event.client_payload.tag }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - run: npm ci
+
+      - name: Generate code
+        id: generate
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+
+          if [ -n "$TAG" ]; then
+            OUTPUT=$(bash .github/workflows/update.sh "$TAG" 2>&1)
+          else
+            OUTPUT=$(bash .github/workflows/update.sh 2>&1)
+          fi
+
+          echo "$OUTPUT"
+
+          if echo "$OUTPUT" | grep -q "Tag already exist"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            RESOLVED_TAG=$(echo "$OUTPUT" | sed -n 's/^Updated to //p')
+            echo "tag=$RESOLVED_TAG" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.generate.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.generate.outputs.tag }}"
+          BRANCH="update/${TAG}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add proto/ src/
+          git commit -m "chore: update to ${TAG}"
+          git push -u origin "$BRANCH"
+
+          WARNINGS=""
+          for dir in src/*/; do
+            service=$(basename "$dir")
+            if ! node -e "const p=require('./package.json'); process.exit(p.scripts['build:${service}'] ? 0 : 1)"; then
+              WARNINGS="$WARNINGS> - \`${service}\` needs a \`build:${service}\` script in package.json"$'\n'
+            fi
+            if ! node -e "const p=require('./package.json'); process.exit(p.exports['./${service}'] ? 0 : 1)"; then
+              WARNINGS="$WARNINGS> - \`${service}\` needs an export entry in package.json"$'\n'
+            fi
+          done
+
+          BODY="Auto-generated update from upstream tag \`${TAG}\`."
+          if [ -n "$WARNINGS" ]; then
+            printf -v BODY '%s\n\n> [!WARNING]\n> **Manual changes needed before merging:**\n>\n%s' "$BODY" "$WARNINGS"
+          fi
+
+          gh pr create \
+            --title "chore: update ${TAG}" \
+            --body "$BODY" \
+            --base main


### PR DESCRIPTION
Introduce GitHub Actions workflows for automated updates and publishing.
- Add `update.yml` to create PRs for upstream tag updates, with warnings for missing build scripts or export entries.
- Add `publish.yml` to publish npm package when update PRs are merged to main.
- Update dependabot config to include Docker.
- Fix update.sh to clone into correct directory.